### PR TITLE
Fix to list/grid style examples and cosmetic changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@ WordPress shortcode for embedding Google Folders
 
 Options include a list or grid style and you can manually set the height/width.
 
-#Grid Style Example
-[gdrive id="YourFolderID" style="Grid" width="100%" height="400px"]
+## Grid-style example
+```wordpress
+[gdrive id="YourFolderID" style="grid" width="100%" height="400px"]
+```
 
-#List Style Example
-[gdrive id="YourFolderID" style="List" width="100%" height="800px"]
+## List-style example
+```wordpress
+[gdrive id="YourFolderID" style="list" width="100%" height="800px"]
+```


### PR DESCRIPTION
So the examples used to state "Grid" and "List" while they should have stated "grid" and "list" (lowercase).
Otherwise they will show as list (default).